### PR TITLE
Simplify logic for the two test notify options

### DIFF
--- a/VsDingExtensionProject/OptionsDialog.cs
+++ b/VsDingExtensionProject/OptionsDialog.cs
@@ -26,7 +26,7 @@ namespace VitaliiGanzha.VsDingExtension
 
         [Category("Beeps")]
         [DisplayName("Failed Tests")]
-        [Description("Beep only when a test failed")]
+        [Description("Beep when a test run is completed and there are failed tests")]
         public bool IsBeepOnTestFailed { get; set; }
 
         [DisplayName("Only when in background")]


### PR DESCRIPTION
Right now the two options for notifying about tests are dependent on each other. Remove the dependency and simplify the logic for notifying.

Beep when a test run is completed -> notify always regarding of outcome
Beep when a test run is completed and there are failed tests -> notify only when there are failed tests
